### PR TITLE
Improve file and dir type options

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -174,6 +174,10 @@ The script will not start if a required field is omitted.
 Allow the option to hold a list of values. Examples: "@", "4", "1,3".
 See L<Getopt::Long/Options-with-multiple-values> for details.
 
+=item * C<class>
+
+Specify the class a "file" or "dir" type option should be instantiated as.
+
 =item * Other
 
 Any other L<Moose> attribute argument may/will be supported in

--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -322,20 +322,19 @@ sub __load_class {
 
 sub _upgrade {
   my ($self, $name, $input) = @_;
-  my $upgraded = $input;
   if (defined $input) {
     my ($option) = grep { $_->{name} =~ /^$name$/ } @{$self->{options}};
     my $class;
     if ($option->{type} =~ /^(file|dir)/ and $class = $option->{isa} and __load_class($class)) {
       if (ref($input) eq 'ARRAY') {
-        $upgraded = [map { $class->new($_) } @$input];
+        $input = [map { $class->new($_) } @$input];
       }
       else {
-        $upgraded = $class->new($input);
+        $input = $class->new("$input");
       }
     }
   }
-  return $upgraded;
+  return $input;
 }
 
 sub _calculate_option_spec {

--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -311,6 +311,7 @@ sub app {
 
 sub __load_class {
   my $class = shift;
+  return 1 if $class->can('new');
   return eval "require $class; 1" ? 1 : 0;
 }
 

--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -174,7 +174,7 @@ The script will not start if a required field is omitted.
 Allow the option to hold a list of values. Examples: "@", "4", "1,3".
 See L<Getopt::Long/Options-with-multiple-values> for details.
 
-=item * C<class>
+=item * C<isa>
 
 Specify the class a "file" or "dir" type option should be instantiated as.
 
@@ -286,6 +286,7 @@ sub app {
     my $switch = $self->_attr_to_option($option->{name});
     push @options_spec, $self->_calculate_option_spec($option);
     $options{$switch} = $option->{default} if exists $option->{default};
+    $options{$switch} = [ @{$options{$switch}} ] if ref($options{$switch}) eq 'ARRAY';
   }
 
   unless ($parser->getoptions(\%options, @options_spec, $self->_default_options)) {
@@ -325,7 +326,7 @@ sub _upgrade {
   if (defined $input) {
     my ($option) = grep { $_->{name} =~ /^$name$/ } @{$self->{options}};
     my $class;
-    if ($option->{type} =~ /^(file|dir)/ and $class = $option->{class} and __load_class($class)) {
+    if ($option->{type} =~ /^(file|dir)/ and $class = $option->{isa} and __load_class($class)) {
       if (ref($input) eq 'ARRAY') {
         $upgraded = [map { $class->new($_) } @$input];
       }
@@ -359,7 +360,7 @@ sub _calculate_option_spec {
     $option->{default}
       and ref $option->{default} ne 'ARRAY'
       and die 'Usage option ... default => [Need to be an array ref]';
-    $option->{default} = [];
+    $option->{default} ||= [];
   }
 
   return $spec;

--- a/t/file-dir.t
+++ b/t/file-dir.t
@@ -1,14 +1,21 @@
+package TestApp::File;
+use overload
+  '""'     => sub { ${$_[0]} },
+  fallback => 1;
+sub new { return bless \(pop), 'TestApp::File'; }
+
+package main;
 use warnings;
 use strict;
 use Test::More;
-use Data::Dumper;
+
 my $app = eval <<"HERE" or die $@;
+package TestApp;
 use Applify;
-use Mojo::File 'path';
-option dir => directory => 'dir', class => 'Mojo::File';
-option file => config_file => 'configuration', class => 'Mojo::File';
-option file => file_list => 'files to process', n_of => '\@', class => 'Mojo::File';
-option file => output => 'output file', default => 'example/output.txt', class => 'Mojo::File';
+option dir => directory => 'dir', class => 'TestApp::File';
+option file => config_file => 'configuration', class => 'TestApp::File';
+option file => file_list => 'files to process', n_of => '\@', class => 'TestApp::File';
+option file => output => 'output file', default => 'example/output.txt', class => 'TestApp::File';
 option str => check => 'simple';
 app {};
 HERE
@@ -18,25 +25,22 @@ my $script = $app->_script;
 {
   local @ARGV = ('--directory', '.');
   my $app = $script->app;
-  isa_ok $app->directory, 'Mojo::File', 'directory option';
-  isa_ok $app->output, 'Mojo::File', 'default';
+  isa_ok $app->directory, 'TestApp::File', 'directory option';
+  isa_ok $app->output, 'TestApp::File', 'default';
   is $app->output, 'example/output.txt', 'output file default';
 }
 
 {
   local @ARGV = ('--directory', 'example');
   my $app = $script->app;
-  isa_ok $app->directory, 'Mojo::File', 'directory option';
-  my $files = $app->directory->list;
-  isa_ok $files, 'Mojo::Collection';
-  my @set = @$files;
-  is_deeply(\@set, [map { "example/$_" } qw{fatpack.sh moo.pl test1.pl}], 'file list');
+  isa_ok $app->directory, 'TestApp::File', 'directory option';
+  ok -d $app->directory, 'directory exists and is a directory';
 }
 
 {
   local @ARGV = ('--config', 'example/moo.pl');
   my $app = $script->app;
-  isa_ok $app->config_file, 'Mojo::File', 'config option';
+  isa_ok $app->config_file, 'TestApp::File', 'config option';
   ok -e $app->config_file, '"config file" exists';
 }
 
@@ -55,7 +59,7 @@ my $script = $app->_script;
   isa_ok $app->file_list, 'ARRAY', 'file list option ';
   ok -e $_, 'file exists' for @{$app->file_list};
   is @{$app->file_list}, 2, 'correct # of files';
-  isa_ok $_, 'Mojo::File', 'file is a Mojo::File' for @{$app->file_list};
+  isa_ok $_, 'TestApp::File', 'file is a TestApp::File' for @{$app->file_list};
 }
 
 

--- a/t/file-dir.t
+++ b/t/file-dir.t
@@ -12,12 +12,12 @@ use Test::More;
 my $app = eval <<"HERE" or die $@;
 package TestApp;
 use Applify;
-option dir => directory => 'dir', class => 'TestApp::File';
-option file => config_file => 'configuration', class => 'TestApp::File';
-option file => file_list => 'files to process', n_of => '\@', class => 'TestApp::File';
-option file => output => 'output file', default => 'example/output.txt', class => 'TestApp::File';
+option dir => directory => 'dir', isa => 'TestApp::File';
+option file => config_file => 'configuration', isa => 'TestApp::File';
+option file => file_list => 'files to process', n_of => '\@', isa => 'TestApp::File';
+option file => output => 'output file', default => 'example/output.txt', isa => 'TestApp::File';
 option file => path_string => 'path as a string only';
-option file => failsafe => 'path as a string only - spurious class', class => 'Not::Existing';
+option file => failsafe => 'path as a string only - spurious class', isa => 'Not::Existing';
 option str => check => 'simple';
 app {};
 HERE

--- a/t/file-dir.t
+++ b/t/file-dir.t
@@ -1,0 +1,74 @@
+use warnings;
+use strict;
+use Test::More;
+use Data::Dumper;
+my $app = eval <<"HERE" or die $@;
+use Applify;
+use Mojo::File 'path';
+option dir => directory => 'dir', class => 'Mojo::File';
+option file => config_file => 'configuration', class => 'Mojo::File';
+option file => file_list => 'files to process', n_of => '\@', class => 'Mojo::File';
+option file => output => 'output file', default => 'example/output.txt', class => 'Mojo::File';
+option str => check => 'simple';
+app {};
+HERE
+
+my $script = $app->_script;
+
+{
+  local @ARGV = ('--directory', '.');
+  my $app = $script->app;
+  isa_ok $app->directory, 'Mojo::File', 'directory option';
+  isa_ok $app->output, 'Mojo::File', 'default';
+  is $app->output, 'example/output.txt', 'output file default';
+}
+
+{
+  local @ARGV = ('--directory', 'example');
+  my $app = $script->app;
+  isa_ok $app->directory, 'Mojo::File', 'directory option';
+  my $files = $app->directory->list;
+  isa_ok $files, 'Mojo::Collection';
+  my @set = @$files;
+  is_deeply(\@set, [map { "example/$_" } qw{fatpack.sh moo.pl test1.pl}], 'file list');
+}
+
+{
+  local @ARGV = ('--config', 'example/moo.pl');
+  my $app = $script->app;
+  isa_ok $app->config_file, 'Mojo::File', 'config option';
+  ok -e $app->config_file, '"config file" exists';
+}
+
+{
+  local @ARGV = ('--file', 'example/moo.pl');
+  my $app = $script->app;
+  isa_ok $app->file_list, 'ARRAY', 'file list option';
+  is @{$app->file_list}, 1, 'correct # of files';
+  my ($first) = @{$app->file_list};
+  ok -e $first, 'file exists';
+}
+
+{
+  local @ARGV = ('--file', 'example/moo.pl', '--file', 'example/test1.pl');
+  my $app = $script->app;
+  isa_ok $app->file_list, 'ARRAY', 'file list option ';
+  ok -e $_, 'file exists' for @{$app->file_list};
+  is @{$app->file_list}, 2, 'correct # of files';
+  isa_ok $_, 'Mojo::File', 'file is a Mojo::File' for @{$app->file_list};
+}
+
+
+is_deeply(run('--directory' => 'example', '--check' => 'this'),  ['example', undef], 'undef');
+
+is_deeply(run('--directory' => 'example', '--config' => 'test'), ['example', 'test'], 'this test');
+
+is_deeply(run('--directory' => 'example', '--file' => 'test1', '--file' => 'test2'), ['example', undef], 'this test');
+
+done_testing;
+
+sub run {
+  local @ARGV = @_;
+  my $app = $script->app;
+  return [$app->directory, $app->config_file];
+}

--- a/t/file-dir.t
+++ b/t/file-dir.t
@@ -16,6 +16,8 @@ option dir => directory => 'dir', class => 'TestApp::File';
 option file => config_file => 'configuration', class => 'TestApp::File';
 option file => file_list => 'files to process', n_of => '\@', class => 'TestApp::File';
 option file => output => 'output file', default => 'example/output.txt', class => 'TestApp::File';
+option file => path_string => 'path as a string only';
+option file => failsafe => 'path as a string only - spurious class', class => 'Not::Existing';
 option str => check => 'simple';
 app {};
 HERE
@@ -23,11 +25,13 @@ HERE
 my $script = $app->_script;
 
 {
-  local @ARGV = ('--directory', '.');
+  local @ARGV = ('--directory', '.', '--path', 'bin', '--failsafe', '/tmp');
   my $app = $script->app;
   isa_ok $app->directory, 'TestApp::File', 'directory option';
   isa_ok $app->output, 'TestApp::File', 'default';
   is $app->output, 'example/output.txt', 'output file default';
+  is ref($app->path_string), '', 'path is a string not one of those objects';
+  is ref($app->failsafe), '', 'failsafe is a string not one of those objects';
 }
 
 {

--- a/t/n_of.t
+++ b/t/n_of.t
@@ -1,0 +1,39 @@
+use warnings;
+use strict;
+use Test::More;
+
+my $app = eval <<"HERE" or die $@;
+use Applify;
+option str => input_file => 'input';
+option str => save => 'save work';
+option str => example => 'array', n_of => '\@';
+option str => defaults => 'array', n_of => '\@', default => [9];
+app {};
+HERE
+
+my $script = $app->_script;
+
+## -save /path
+is_deeply(run('--save' => '/tmp/1'),     [[], undef, '/tmp/1', [9]], 'save only');
+
+## set -e and -i
+is_deeply(run('-e' => 1, '-e', 2, '-i' => '/tmp/3'), [[1, 2], '/tmp/3', undef, [9]], 'arrays');
+
+## neither -i nor -e should be set...
+is_deeply(run('--save' => '/tmp/1'),     [[], undef, '/tmp/1', [9]], 'saved?');
+
+## only -i
+is_deeply(run('-i' => '/tmp/1'),     [[], '/tmp/1', undef, [9]], 'input only');
+
+is_deeply(run('-e' => 1, '-e', 2, '-i' => '/tmp/3'), [[1, 2], '/tmp/3', undef, [9]], 'arrays again');
+
+## defaults
+is_deeply(run('-d' => 8, '-d' => 7), [[], undef, undef, [9, 8, 7]], 'push...');
+
+done_testing;
+
+sub run {
+  local @ARGV = @_;
+  my $app = $script->app;
+  return [$app->example, $app->input_file, $app->save, $app->defaults];
+}


### PR DESCRIPTION
## Summary

Options with type *file* and *dir* are currently marked *TODO* and behave as *str* it would be nice for them to be more helpful. This moves beyond that, with `Mojo::File` objects, or lists of, being created.
