### PR TITLE
Extracting POD synopsis from FatPacked modules

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -350,6 +350,16 @@ sub _print_synopsis {
   unless (-e $documentation) {
     eval "use $documentation; 1" or die "Could not load $documentation: $@";
     $documentation =~ s!::!/!g;
+    # might be FatPacked $INC{"$documentation.pm"}{"$documentation.pm"}
+    if (ref($INC{"$documentation.pm"})) {
+      my @lines = split /\r?\n/, $INC{"$documentation.pm"}{"$documentation.pm"};
+      for (@lines) {
+        last if $print and /^=(?:cut|head1)/;
+        print if $print;
+        $print = 1 if /^=head1 SYNOPSIS/;
+      }
+      return ;
+    }
     $documentation = $INC{"$documentation.pm"};
   }
 

--- a/t/help.t
+++ b/t/help.t
@@ -1,3 +1,35 @@
+use strict;
+use warnings;
+## This BEGIN block
+BEGIN {
+my %fatpacked;
+
+$fatpacked{"Help/Class.pm"} = '#line '.(1+__LINE__).' "'.__FILE__."\"\n".<<'HELP_CLASS';
+  package Help::Class;
+  1;
+  __END__
+  =head1 SYNOPSIS
+
+  How to run your script.
+
+  =cut
+
+HELP_CLASS
+s/^  //mg for values %fatpacked;
+my $class = 'FatPacked::'.(0+\%fatpacked);
+no strict 'refs';
+*{"${class}::files"} = sub { keys %{$_[0]} };
+*{"${class}::INC"} = sub {
+  if (my $fat = $_[0]{$_[1]}) {
+    open my $fh, '<', \$fat
+      or die "FatPacker error loading $_[1] (could be a perl installation issue?)";
+    return $fh;
+  }
+  return;
+};
+unshift @INC, bless \%fatpacked, $class;
+} ## END of FatPacked code
+
 use lib '.';
 use t::Helper;
 
@@ -33,6 +65,24 @@ is_deeply [$script->_default_options], [qw(help man version)], 'default options 
 is + (run_method($script, 'print_help'))[0], <<'HERE', 'print_help()';
 
 dummy synopsis...
+
+Usage:
+   --foo-bar  Foo can something
+   --foo-2    foo_2 can something else
+ * --foo-3    foo_3 can also something
+
+   --help     Print this help text
+   --man      Display manual for this application
+   --version  Print application name and version
+
+HERE
+
+
+$script->documentation("Help::Class");
+
+is + (run_method($script, 'print_help'))[0], <<'HERE', 'print_help() with fatpacked code';
+
+How to run your script.
 
 Usage:
    --foo-bar  Foo can something

--- a/t/help.t
+++ b/t/help.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
-## This BEGIN block
+## This BEGIN block is a minimal fatpack entry
+## see perldoc App::FatPacker and perldoc -f require
 BEGIN {
 my %fatpacked;
 


### PR DESCRIPTION
I'm considering fatpacking some applify scripts and have found that when using something akin to the included code. The `_print_help` doesn't when the script is fatpacked for the `script list -help` as `$INC{'App/Command/List.pm'}` is a `FatPacked::HASH` that cannot be opened. `script -help` is functional fatpacked, as is `script list -help` in un-fatpacked form.

```perl
documentation __FILE__;
subcommand list => 'list all possible outcomes' => sub {
  documentation 'App::Command::List';
};
```

This appears to fix it but needs improvement and tests for which I'm at a loss on how to construct.