### PR TITLE
More helpful help

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -176,7 +176,7 @@ OPTION:
     );
   }
 
-  print "notes:\n";
+  print "Notes:\n";
   print " * denotes a required option\n";
   print " + denotes an option that accepts multiple values\n";
   return $self;

--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -170,12 +170,15 @@ OPTION:
 
     printf(
       " %s %2s%-${width}s  %s\n",
-      $option->{required} ? '*'  : ' ',
+      $option->{required} ? '*'  : $option->{n_of} ? '+' : ' ',
       length($name) > 1   ? '--' : '-',
       $name, $option->{documentation},
     );
   }
 
+  print "notes:\n";
+  print " * denotes a required option\n";
+  print " + denotes an option that accepts multiple values\n";
   return $self;
 }
 

--- a/t/help.t
+++ b/t/help.t
@@ -56,7 +56,7 @@ Usage:
 
    --help     Print this help text
 
-notes:
+Notes:
  * denotes a required option
  + denotes an option that accepts multiple values
 HERE
@@ -82,7 +82,7 @@ Usage:
    --man      Display manual for this application
    --version  Print application name and version
 
-notes:
+Notes:
  * denotes a required option
  + denotes an option that accepts multiple values
 HERE
@@ -104,7 +104,7 @@ Usage:
    --man      Display manual for this application
    --version  Print application name and version
 
-notes:
+Notes:
  * denotes a required option
  + denotes an option that accepts multiple values
 HERE

--- a/t/help.t
+++ b/t/help.t
@@ -40,6 +40,7 @@ my $script = $app->_script;
 $script->option(str => foo_bar => 'Foo can something');
 $script->option(str => foo_2   => 'foo_2 can something else', 42);
 $script->option(str => foo_3   => 'foo_3 can also something', 123, required => 1);
+$script->option(str => foo_4   => 'foo_4 can also something', 123, n_of => '@');
 
 my $application_class = $script->_generate_application_class(sub { });
 like $application_class, qr{^Applify::__ANON__2__::}, 'generated application class';
@@ -51,9 +52,13 @@ Usage:
    --foo-bar  Foo can something
    --foo-2    foo_2 can something else
  * --foo-3    foo_3 can also something
+ + --foo-4    foo_4 can also something
 
    --help     Print this help text
 
+notes:
+ * denotes a required option
+ + denotes an option that accepts multiple values
 HERE
 
 eval { $script->documentation(undef) };
@@ -71,11 +76,15 @@ Usage:
    --foo-bar  Foo can something
    --foo-2    foo_2 can something else
  * --foo-3    foo_3 can also something
+ + --foo-4    foo_4 can also something
 
    --help     Print this help text
    --man      Display manual for this application
    --version  Print application name and version
 
+notes:
+ * denotes a required option
+ + denotes an option that accepts multiple values
 HERE
 
 
@@ -89,11 +98,15 @@ Usage:
    --foo-bar  Foo can something
    --foo-2    foo_2 can something else
  * --foo-3    foo_3 can also something
+ + --foo-4    foo_4 can also something
 
    --help     Print this help text
    --man      Display manual for this application
    --version  Print application name and version
 
+notes:
+ * denotes a required option
+ + denotes an option that accepts multiple values
 HERE
 
 done_testing;

--- a/t/subcommand.t
+++ b/t/subcommand.t
@@ -121,7 +121,7 @@ options:
 
    --help        Print this help text
 
-notes:
+Notes:
  * denotes a required option
  + denotes an option that accepts multiple values
 HERE
@@ -151,7 +151,7 @@ options:
 
    --help        Print this help text
 
-notes:
+Notes:
  * denotes a required option
  + denotes an option that accepts multiple values
 HERE

--- a/t/subcommand.t
+++ b/t/subcommand.t
@@ -121,6 +121,9 @@ options:
 
    --help        Print this help text
 
+notes:
+ * denotes a required option
+ + denotes an option that accepts multiple values
 HERE
 
 }
@@ -148,6 +151,9 @@ options:
 
    --help        Print this help text
 
+notes:
+ * denotes a required option
+ + denotes an option that accepts multiple values
 HERE
 
 }


### PR DESCRIPTION
A cosmetic change to the dynamic help text.

This labels `n_of` options with a `+` and includes a notes section to explain what the `*` and `+` indicate. An example, taken from the tests, follows.

    Usage:
       --foo-bar  Foo can something
       --foo-2    foo_2 can something else
     * --foo-3    foo_3 can also something
     + --foo-4    foo_4 can also something
    
       --help     Print this help text
    
    notes:
     * denotes a required option
     + denotes an option that accepts multiple values
