### PR TITLE
Add support for isa => Type::Tiny object #15

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,8 @@ Revision history for perl distribution Applify
    Contributor: Roy Storey
  - Add "has_attribute" predicate methods #13
    Contributor: Roy Storey
+ - Add support for options with "isa" being a Type::Tiny object #15
+ - Add support for option's "default" being a code-ref
  - Allow --foo_bar as well as --foo-bar
 
 0.15 2018-06-06T22:52:43+0800

--- a/t/options.t
+++ b/t/options.t
@@ -33,6 +33,12 @@ $script->option(str => foo_3 => 'foo_3 can also something', 123, required => 1);
 is $script->options->[2]{default},  123, 'foo_3 has default value';
 is $script->options->[2]{required}, 1,   'foo_3 is required';
 
+$script->option(str => foo_4 => 'foo_4 can something else' => sub { });
+is ref($script->options->[3]{default}), 'CODE', 'foo_4 has default code';
+
+$script->option(str => foo_5 => 'foo_5 can something else', default => sub { });
+is ref($script->options->[4]{default}), 'CODE', 'foo_5 has default code';
+
 is $script->_calculate_option_spec({name => 'a_b', arg => 'a-b', type => 'bool'}), 'a_b|a-b!',  'a_b!';
 is $script->_calculate_option_spec({name => 'a_b', arg => 'a-b', type => 'flag'}), 'a_b|a-b!',  'a_b!';
 is $script->_calculate_option_spec({name => 'a_b', arg => 'a-b', type => 'inc'}),  'a_b|a-b+',  'a_b+';
@@ -70,8 +76,10 @@ $script = $app->_script;
 my $instance = app_instance($script, qw{-input-file /tmp/test});
 is $instance->has_input_file, 1, 'Moose style';
 is !$instance->has_iii, 1, 'does not exist';
-is $instance->has_output_file, 1,       'default always exists';
-is $instance->has_template,    0,       'has_template not replaced see _sub()';
+ok !$instance->has_output_file, 'default does not exist yet';
+$instance->output_file;
+ok $instance->has_output_file, 'default applied';
+is $instance->has_template,    0, 'has_template not replaced see _sub()';
 is $instance->template,        'empty', 'default exists';
 
 sub app_instance {

--- a/t/type-tiny.t
+++ b/t/type-tiny.t
@@ -1,0 +1,44 @@
+use warnings;
+use strict;
+use Test::More;
+
+plan skip_all => 'Types::Standard is required' unless eval 'require Types::Standard;1';
+
+my $app = eval <<'HERE' or die $@;
+use Applify;
+use Types::Standard qw(ArrayRef Bool Int);
+option bool => give_cookies => 'give', isa => Bool;
+option int => n_cookies => 'cookies', isa => Int;
+option int => people_ages => 'ages', isa => ArrayRef[Int], n_of => '@', default => sub { [qw(12 24 44)] };
+app {};
+HERE
+
+{
+  no warnings qw(once redefine);
+  *Applify::print_help = sub { $main::help++ };
+}
+
+my $script = $app->_script;
+
+is_deeply(run('--give-cookies'), [1, undef, [qw(12 24 44)]], 'type bool') or diag $@;
+is_deeply(run('--n-cookies',   5),  [undef, 5,     [qw(12 24 44)]], 'type int')   or diag $@;
+is_deeply(run('--people-ages', 10), [undef, undef, [qw(10)]],       'type array') or diag $@;
+
+eval { $app->n_cookies('yikes') };
+like "$@", qr{Failed check for "n_cookies".*"yikes"}s, '$app->n_cookies not int';
+
+run('--n-cookies', 'foo');
+like "$@", qr{Invalid input:.*foo}s, 'n_cookies not int';
+
+run('--people-ages', 'bar');
+like "$@", qr{Failed check for --people-ages:.*"bar"}s, 'people_ages not int';
+
+done_testing;
+
+sub run {
+  local @ARGV = @_;
+  return eval {
+    my $app = $script->app;
+    [$app->give_cookies, $app->n_cookies, $app->people_ages];
+  } || [];
+}


### PR DESCRIPTION
This PR implements the request in #15, and fixes a couple of weird things.

Here is an example output:

```
$ test_app --people-ages bar
Usage:
...
Notes:
...
Invalid input:

Failed check for --people-ages: Reference ["bar"] did not pass type constraint "ArrayRef[Num]"
```

What do you think @srchulo?