### PR TITLE
Fix options with isa and no default?

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -319,7 +319,7 @@ sub _generate_attribute_accessor {
     return sub {
       @_ == 1 && exists $_[0]{$name} && return $_[0]{$name};
       my $val = @_ > 1 ? $_[1] : $_[0]->$default;
-      $_[0]{$name} = ref $val eq 'ARRAY' ? [map { $class->new($_) } @$val] : $class->new($val);
+      $_[0]{$name} = ref $val eq 'ARRAY' ? [map { $class->new($_) } @$val] : defined($val) ? $class->new($val) : undef;
     };
   }
   else {

--- a/t/file-dir.t
+++ b/t/file-dir.t
@@ -2,7 +2,7 @@ package TestApp::File;
 use overload
   '""'     => sub { ${$_[0]} },
   fallback => 1;
-sub new { return bless \(pop), 'TestApp::File'; }
+sub new { die "Invalid" unless $_[1]; return bless \(pop), 'TestApp::File'; }
 
 package main;
 use warnings;


### PR DESCRIPTION
A quick patch for consideration.

Should an `undef` default lead to an *object* for the attribute, or an `undef`? This happens in the following case where no `--input` is specified. `->has_input` also then returns true, which doesn't seem correct.

```perl
use Applify;
option file => input => 'just input' => isa => 'Mojo::File';
app {};
```
