### PR TITLE
Correct message in command line apps

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -53,7 +53,7 @@ sub app {
     $self->{application_class}->new(\%argv);
   } or do {
     $@ =~ s!\sat\s.*!!s unless $ENV{APPLIFY_VERBOSE};
-    $self->print_help;
+    { local $@; $self->print_help; }
     local $! = 1;    # exit value
     die "\nInvalid input:\n\n$@\n";
   };

--- a/t/type-tiny.t
+++ b/t/type-tiny.t
@@ -15,7 +15,7 @@ HERE
 
 {
   no warnings qw(once redefine);
-  *Applify::print_help = sub { $main::help++ };
+  *Applify::print_help = sub { eval { $main::help++ } };
 }
 
 my $script = $app->_script;


### PR DESCRIPTION
I think this one slipped through. `print_help` has two child functions that `eval {}` overwriting `$@`, resulting in an empty message about invalid input. 