### PR TITLE
Configuring option parser

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -87,6 +87,9 @@ sub import {
 
   $self->{skip_subs} = {app => 1, option => 1, version => 1, documentation => 1, extends => 1, subcommand => 1};
 
+  $self->option_parser->configure(@{delete $args{getopt_config}})
+    if $args{getopt_config};
+
   no strict 'refs';
   for my $name (keys %$ns) {
     $self->{'skip_subs'}{$name} = 1;
@@ -757,6 +760,19 @@ a normalized matter. Example:
 
 Will export the functions listed under L</EXPORTED FUNCTIONS>. The functions
 will act on a L<Applify> object created by this method.
+
+Additionally, C<import> accepts the following named arguments with the following
+names:
+
+=over 4
+
+=item getopt_config
+
+An array reference that must contain configure options for L<Getopt::Long|Getopt::Long/Configure>.
+
+  use Applify getopt_config => [qw(no_auto_help no_pass_through)];
+
+=back
 
 =head1 COPYRIGHT & LICENSE
 

--- a/t/options.t
+++ b/t/options.t
@@ -11,6 +11,16 @@ getopt_long_config_ok($script->option_parser,
   [qw(no_auto_help no_auto_version pass_through)],
   'Getopt::Long has correct config');
 
+$app    =
+  eval 'use Applify getopt_config => [qw(bundling no_pass_through)]; app {0};' or die $@;
+$script = $app->_script;
+
+isa_ok $script->option_parser, 'Getopt::Long::Parser';
+
+getopt_long_config_ok($script->option_parser,
+  [qw(no_auto_help no_auto_version bundling no_pass_through)],
+  'Getopt::Long has correct config');
+
 eval { $script->option(undef) };
 like($@, qr{^Usage:.*type =>}, 'option() require type');
 eval { $script->option(str => undef) };

--- a/t/options.t
+++ b/t/options.t
@@ -7,10 +7,9 @@ my $script = $app->_script;
 
 isa_ok $script->option_parser, 'Getopt::Long::Parser';
 
-{
-  local $TODO = 'need to define config for Getopt::Long';
-  is_deeply($script->option_parser->{settings}, [qw(no_auto_help pass_through)], 'Getopt::Long has correct config');
-}
+getopt_long_config_ok($script->option_parser,
+  [qw(no_auto_help no_auto_version pass_through)],
+  'Getopt::Long has correct config');
 
 eval { $script->option(undef) };
 like($@, qr{^Usage:.*type =>}, 'option() require type');
@@ -87,6 +86,12 @@ sub app_instance {
   local @ARGV = @_;
   my $app = $script->app;
   return $app;
+}
+
+sub getopt_long_config_ok {
+  my ($parser, $expected, $desc) = @_;
+  my $save = Getopt::Long::Configure(@$expected);
+  return is_deeply($parser->{settings}, Getopt::Long::Configure($save), $desc);
 }
 
 done_testing;


### PR DESCRIPTION
As an alternative to #20.

```perl
use Applify getopt_config => [qw(no_auto_help no_pass_through)];
```