### PR TITLE
Bump minimum required Perl version to 5.14.4

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 # You can install this project with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/applify/archive/master.tar.gz
-requires "perl" => "5.010001";
+requires "perl" => "5.014004";
 requires "Cwd" => "3.31",
 requires "File::Basename" => "2.70",
 requires "Getopt::Long" => "2.38",


### PR DESCRIPTION
CPAN testers are not able to install this module on Perl versions below 5.14.4.