### PR TITLE
Add missing 'arg' attribute in call to _calculate_option_spec

### DIFF
--- a/t/options.t
+++ b/t/options.t
@@ -50,7 +50,7 @@ is $script->_calculate_option_spec({name => 'a_b', arg => 'a-b', type => 'num', 
   is $script->_calculate_option_spec({name => 'a_b', arg => 'a-b', type => 'dir'}),  'a_b|a-b=s', 'a_b=s';
 }
 
-eval { $script->_calculate_option_spec({name => 'a_b', type => 'uri'}); };
+eval { $script->_calculate_option_spec({name => 'a_b', arg => 'a-b', type => 'uri'}); };
 like $@, qr/^Usage: option /, 'die on unsupported option type';
 
 


### PR DESCRIPTION
Some options tests call _calculate_option_spec() directly, thus bypassing
the initialization of the 'arg' attribute usually performed by option().

Not specifying 'arg' leads to "Use of uninitialized value" errors