### PR TITLE
remove listing of subcommands for subcommand help

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -165,7 +165,12 @@ sub print_help {
   my $width   = 0;
   my %notes;
 
-  $self->_print_synopsis;
+  # application help, or subcommand help?
+  my $app_help = ! defined $self->{subcommand};
+
+  if ( $app_help ) {
+      $self->_print_synopsis;
+  }
 
 OPTION:
   for my $option (@options) {
@@ -175,13 +180,21 @@ OPTION:
 
   print "Usage:\n";
 
-  if (%{$self->{subcommands} || {}}) {
-    my $subcmds = [sort { $a->{name} cmp $b->{name} } values %{$self->{subcommands}}];
-    my ($width) = sort { $b <=> $a } map { length($_->{name}) } @$subcmds;
-    print "\n    ", File::Basename::basename($0), " [command] [options]\n";
-    print "\nCommands:\n";
-    printf("    %-${width}s  %s\n", @{$_}{'name', 'desc'}) for @$subcmds;
-    print "\nOptions:\n";
+  if ( $app_help  ) {
+
+    if (%{$self->{subcommands} || {}}) {
+      my $subcmds = [sort { $a->{name} cmp $b->{name} } values %{$self->{subcommands}}];
+      my ($width) = sort { $b <=> $a } map { length($_->{name}) } @$subcmds;
+      print "\n    ", File::Basename::basename($0), " [command] [options]\n";
+      print "\nCommands:\n";
+      printf("    %-${width}s  %s\n", @{$_}{'name', 'desc'}) for @$subcmds;
+      print "\nOptions:\n";
+    }
+
+  }
+  else {
+      print "\n    ", File::Basename::basename($0), " ", $self->{subcommand}, " [options]\n";
+      print "\nOptions:\n";
   }
 
   $width += 2;

--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -165,37 +165,36 @@ sub print_help {
   my $width   = 0;
   my %notes;
 
-  # application help, or subcommand help?
-  my $app_help = ! defined $self->{subcommand};
-
-  if ( $app_help ) {
-      $self->_print_synopsis;
-  }
-
-OPTION:
   for my $option (@options) {
     my $length = length($option->{name} || '');
     $width = $length if $width < $length;
   }
 
-  print "Usage:\n";
-
-  if ( $app_help  ) {
-
-    if (%{$self->{subcommands} || {}}) {
-      my $subcmds = [sort { $a->{name} cmp $b->{name} } values %{$self->{subcommands}}];
-      my ($width) = sort { $b <=> $a } map { length($_->{name}) } @$subcmds;
-      print "\n    ", File::Basename::basename($0), " [command] [options]\n";
-      print "\nCommands:\n";
-      printf("    %-${width}s  %s\n", @{$_}{'name', 'desc'}) for @$subcmds;
-      print "\nOptions:\n";
-    }
-
+  # subcommand help?
+  if ($self->{subcommand}) {
+    print "Usage:\n";
+    print "\n    ", File::Basename::basename($0), " ", $self->{subcommand}, " [options]\n";
   }
+
+  # top level help with subcommands?
+  elsif (%{$self->{subcommands} || {}}) {
+    $self->_print_synopsis;
+    print "Usage:\n";
+    my $subcmds = [sort { $a->{name} cmp $b->{name} } values %{$self->{subcommands}}];
+    my ($width) = sort { $b <=> $a } map { length($_->{name}) } @$subcmds;
+    print "\n    ", File::Basename::basename($0), " [command] [options]\n";
+    print "\nCommands:\n";
+    printf("    %-${width}s  %s\n", @{$_}{'name', 'desc'}) for @$subcmds;
+  }
+
+  # top level help, no subcommands
   else {
-      print "\n    ", File::Basename::basename($0), " ", $self->{subcommand}, " [options]\n";
-      print "\nOptions:\n";
+    $self->_print_synopsis;
+    print "Usage:\n";
+    print "\n    ", File::Basename::basename($0), " [options]\n";
   }
+
+  print "\nOptions:\n";
 
   $width += 2;
 

--- a/t/help.t
+++ b/t/help.t
@@ -50,6 +50,10 @@ is_deeply $script->_default_options,
   [{arg => 'help', documentation => 'Print this help text', name => 'help', type => 'bool'}], 'default options';
 is_help $script, <<'HERE', 'only help';
 Usage:
+
+    help.t [options]
+
+Options:
     --foo-bar  Foo can something
     --foo-2    foo_2 can something else
  *  --foo-3    foo_3 can also something
@@ -77,6 +81,10 @@ is_help $script, <<'HERE', 'help, man, version';
 dummy synopsis...
 
 Usage:
+
+    help.t [options]
+
+Options:
     --foo-bar  Foo can something
     --foo-2    foo_2 can something else
  *  --foo-3    foo_3 can also something
@@ -100,6 +108,10 @@ is_help $script, <<'HERE', 'fatpacked code';
 How to run your script.
 
 Usage:
+
+    help.t [options]
+
+Options:
     --foo-bar  Foo can something
     --foo-2    foo_2 can something else
  *  --foo-3    foo_3 can also something

--- a/t/subcommand.t
+++ b/t/subcommand.t
@@ -116,11 +116,7 @@ HERE
   is_help $script, <<'HERE', 'subcommand log';
 Usage:
 
-    subcommand.t [command] [options]
-
-Commands:
-    list  provide a listing
-    log   provide a log
+    subcommand.t log [options]
 
 Options:
     --input-file  input


### PR DESCRIPTION
Subcommand help also provided a listing of the subcommands,
e.g. (from the tests), running

  subcommand.t log --help

results in

      Usage:

          subcommand.t [command] [options]

      Commands:
          list  provide a listing
          log   provide a log

      Options:
          --input-file  input
          --save        save work
       *  --age         age of log

          --help        Print this help text

The subcommands should only be provided when requesting help at the
top level.  This change results in the following help output for the
log subcommand:

      Usage:

          subcommand.t log [options]

      Options:
          --input-file  input
          --save        save work
       *  --age         age of log

          --help        Print this help text