### PR TITLE
add changes to allow full subclassing of Applify

### DIFF
--- a/lib/Applify.pm
+++ b/lib/Applify.pm
@@ -353,8 +353,8 @@ sub _generate_application_class {
   local $@;
   eval qq[package $application_class; use base qw(@$extends); 1] or die "Failed to generate application class: $@";
 
-  _sub("$application_class\::new"     => \&_app_new) unless grep { $_->can('new') } @$extends;
-  _sub("$application_class\::run"     => \&_app_run);
+  _sub("$application_class\::new"     => sub { $self->can('_app_new')->(@_) } ) unless grep { $_->can('new') } @$extends;
+  _sub("$application_class\::run"     => sub { $self->can('_app_run')->(@_) } );
   _sub("$application_class\::_script" => sub {$self});
 
   for ('app', $self->{caller}[0]) {

--- a/t/subclass.t
+++ b/t/subclass.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+
+{ package MyApplify;
+
+  use parent 'Applify';
+
+  sub _app_run {
+      my ($app, @extra) = @_;
+      $app->foo(22);
+      $app->SUPER::_app_run( @extra );
+  }
+
+}
+
+my $app = eval q[
+  use v5.10;
+  BEGIN {
+    MyApplify->import;
+  }
+  option int => foo => 'foo';
+  app { return 0; };
+];
+
+ok $app, 'app was constructed'
+  or diag $@;
+$app->run;
+is $app->foo, 22, 'foo() returns 22' if $app;
+
+done_testing;


### PR DESCRIPTION
It is *almost* possible to subclass Applify, which would allow for
more customization than is currently possible.  The only remaining
changes required are to the installation of _app_run() and _app_new()
into the application class.  The new code installs wrappers which
ensure that the methods used follow the class inheritance.