### PR TITLE
add after_options_parsing hook

### DIFF
--- a/t/hook.t
+++ b/t/hook.t
@@ -5,11 +5,17 @@ use Test::More;
 my $app = eval <<'HERE' or die $@;
 use Applify;
 
+option str => test => 'test option', default => 42;
+
 my $i = 0;
 
 hook before_options_parsing => sub {
   $ENV{TEST_OPTIONS} = join ':', @{$_[1]};
   shift->option_parser->configure(qw(bundling no_pass_through)) if $i++;
+};
+
+hook after_options_parsing => sub {
+  $_[1]->{test} = 43;
 };
 
 hook before_exit => sub { die "before_exit:$_[1]" };
@@ -29,6 +35,7 @@ eval {
 } or do {
   like $@, qr{^before_exit:42}, 'before_exit';
   is $ENV{TEST_OPTIONS}, 'a:b:c', 'before_options_parsing argv';
+  is $app->test,         43,      'after_options_parsing argv';
   ok_option_parser_config([qw(no_auto_help no_auto_version bundling no_pass_through)], 'modified option_parser config');
 };
 


### PR DESCRIPTION
I'd like to gain access to the parsed command line arguments before they are passed on to the application so that I can modify them. This is another approach to #35 with more context, and is a refinement of the idea in #28.  Your suggestion in #28 was to introduce roles, but I think this approach, while not as general, is much less invasive.

From the commit:

This hook provides a means of modifying the parsed options prior to
passing them to the application or subcommands.  This could be used
for more complex options validation, or as a means of centralizing
configuration file processing, e.g.:
```
  use Config::Tiny;
  hook after_options_parsing => sub {
    my ( $script, $argv ) = @_;

    if ( defined $argv->{config} ) {
        my $config = Config::Tiny->read( $argv->{config} );
        # read root section for global options
        $argv->{$_} //= $config->{_}{$_} for keys %{$config->{_}};
        # read subcommand section
        if ( $script->{subcommand} && $config->{$script->{subcommand}} ) {
           my $subcfg = $config->{$script->{subcommand}};
           $argv->{$_} //= $subcfg->{$_} for keys %$subcfg;
        }
    }
  };
```